### PR TITLE
Provider global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,47 @@ composer_project "vendor" do
 end
 ```
 
-## Usage
+### `composer_install_global`
+
+#### Actions
+- :install: Install the given vendor in the given install_dir and creates symlinks.
+- :update: Gets the latest versions of the dependencies in the given install_dir
+- :remove Removes vendor from composer.json and uninstalls it with all dependencies
+
+#### Attribute parameters
+- vendor: The name attribute, what package to install
+- install_dir: The directory where the packages will be installed
+- dev: Install packages listed in require-dev, default false
+- quiet: Do not output any message, default true
+- optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
+- prefer_dist: Install packages from dist when available, default false
+- prefer_source: Install packages from source when available, default false
+- user: The user as whichs to execute the commands, default root
+- group: The group as whichs to execute the commands, default root
+- umask: The umask to use during commands, default 0002
+
+#### Examples
+```
+#install project vendor/vendor
+composer_install_global "vendor/vendor" do
+    install_dir "/path/to/project"
+    action :install
+end
+
+#update project vendor/vendor
+composer_install_global "vendor/vendor" do
+    install_dir "/path/to/project"
+    action :update
+end
+
+#remove project vendor/vendor
+composer_install_global "vendor/vendor" do
+    install_dir "/path/to/project"
+    action :remove
+end
+```
+
+## Usage
 
 1. include `recipe[composer]` in a run list
 2. tweak the attributes via attributes/default.rb

--- a/README.md
+++ b/README.md
@@ -47,18 +47,25 @@ This cookbook includes an LWRP for managing a Composer project
 - :require Create composer.json file using specified vendor and downloads vendor.
 - :update: Gets the latest versions of the dependencies and updates the composer.lock file
 - :dump_autoload: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
-- :remove Removes vendor from composer.json and uninstalls
+- :remove Removes vendor from composer.json and uninstalls with all dependencies
 
 #### Attribute parameters
+- vendor: The name attribute, what package to install
 - project_dir: The directory where your project's composer.json can be found
 - dev: Install packages listed in require-dev, default false
 - quiet: Do not output any message, default true
 - optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
+- prefer_dist: Install packages from dist when available, default false
+- prefer_source: Install packages from source when available, default false
+- user: The user as whichs to execute the commands, default root
+- group: The group as whichs to execute the commands, default root
+- umask: The umask to use during commands, default 0002
 
 #### Examples
 ```
 #install project vendors
-composer_project "/path/to/project" do
+composer_project "vendors" do
+    project_dir "/path/to/project"
     dev false
     quiet true
     prefer_dist false
@@ -66,7 +73,8 @@ composer_project "/path/to/project" do
 end
 
 #require project vendor
-composer_project "/path/to/project" do
+composer_project "vendor" do
+    project_dir "/path/to/project"
     dev false
     quiet true
     prefer_dist false
@@ -74,22 +82,24 @@ composer_project "/path/to/project" do
 end
 
 #update project vendors
-composer_project "/path/to/project" do
+composer_project "vendors" do
+    project_dir "/path/to/project"
     dev false
     quiet true
     action :update
 end
 
-#dump-autoload for project
-composer_project "/path/to/project" do
+#dump-autoload for project vendor
+composer_project "vendor" do
+    project_dir "/path/to/project"
     dev false
     quiet true
     action :dump_autoload
 end
 
 #remove project vendor
-composer_project "/path/to/project" do
-    vendor 'repo/vendor'
+composer_project "vendor" do
+    project_dir "/path/to/project"
     action :remove
 end
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,88 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2".freeze
+
+Vagrant.require_version ">= 1.5.0"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  config.vm.hostname = "composer"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+
+  # Set the version of chef to install using the vagrant-omnibus plugin
+  # NOTE: You will need to install the vagrant-omnibus plugin:
+  #
+  #   $ vagrant plugin install vagrant-omnibus
+  #
+  if Vagrant.has_plugin?("vagrant-omnibus")
+    config.omnibus.chef_version = "12.13.37"
+  end
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  # If this value is a shorthand to a box in Vagrant Cloud then
+  # config.vm.box_url doesn"t need to be specified.
+  config.vm.box = "bento/centos-7.2"
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  # config.vm.network :private_network, type: "dhcp"
+  config.vm.network :public_network
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network :forwarded_port, guest: 80, host: 8080
+  # config.vm.network :forwarded_port, guest: 8080, host: 8081
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  # config.berkshelf.berksfile_path = "./Berksfile"
+
+  # Enabling the Berkshelf plugin. To enable this globally, add this
+  # configuration option to your ~/.vagrant.d/Vagrantfile file
+  config.berkshelf.enabled = true
+
+  # An array of symbols representing groups of cookbook described in the
+  # Vagrantfile to exclusively install and copy to Vagrant's shelf.
+  # config.berkshelf.only = []
+
+  # An array of symbols representing groups of cookbook described in the
+  # Vagrantfile to skip installing and copying to Vagrant's shelf.
+  # config.berkshelf.except = []
+
+  config.vm.provision :chef_solo do |chef|
+    chef.run_list = [
+      "recipe[composer::test]"
+    ]
+  end
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,7 @@ else
   default['composer']['url'] = 'http://getcomposer.org/composer.phar'
   default['composer']['install_dir'] = '/usr/local/bin'
   default['composer']['bin'] = "#{node['composer']['install_dir']}/composer"
+  default['composer']['bin_dir'] = '/usr/local/bin'
   default['composer']['install_globally'] = true
   default['composer']['mask'] = 0755
   default['composer']['link_type'] = :symbolic

--- a/libraries/composer.rb
+++ b/libraries/composer.rb
@@ -7,4 +7,8 @@ module Composer
   def self.home_dir(node)
     node['composer']['home_dir'] || install_dir(node)
   end
+
+  def self.bin_dir(node)
+    node['composer']['bin_dir'] || ''
+  end
 end

--- a/providers/install_global.rb
+++ b/providers/install_global.rb
@@ -1,0 +1,95 @@
+#
+# Cookbook Name:: composer
+# Resource:: install_global
+#
+# Copyright 2012-2014, Escape Studios
+#
+
+use_inline_resources if defined?(use_inline_resources)
+
+def whyrun_supported?
+  true
+end
+
+action :install do
+  install_global_install
+  new_resource.updated_by_last_action(true)
+end
+
+action :remove do
+  install_global_remove
+  new_resource.updated_by_last_action(true)
+end
+
+action :update do
+  install_global_update
+  new_resource.updated_by_last_action(true)
+end
+
+def install_global_install
+  dev = new_resource.dev ? '--dev' : '--no-dev'
+  quiet = new_resource.quiet ? '--quiet' : ''
+  optimize = new_resource.optimize_autoloader ? optimize_flag(cmd) : ''
+  prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
+  prefer_source = new_resource.prefer_source ? '--prefer-source' : ''
+
+  directory new_resource.install_dir do
+    recursive true
+    user new_resource.user
+    group new_resource.group
+  end
+
+  composer_project new_resource.vendor do
+    project_dir new_resource.install_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    user new_resource.user
+    group new_resource.group
+    umask new_resource.umask
+    action :require
+  end
+
+  # Set the bin_dir for completeness
+  execute 'set-bin_dir' do
+    cwd new_resource.install_dir
+    command "#{node['composer']['bin']} config bin-dir #{node['composer']['bin_dir']} #{quiet}"
+    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    action :run
+    user new_resource.user
+    group new_resource.group
+    umask new_resource.umask
+  end
+end
+
+def install_global_remove
+  composer_project new_resource.vendor do
+    project_dir new_resource.install_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    user new_resource.user
+    group new_resource.group
+    umask new_resource.umask
+    action :remove
+  end
+end
+
+def install_global_update
+  composer_project new_resource.vendor do
+    project_dir new_resource.install_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    user new_resource.user
+    group new_resource.group
+    umask new_resource.umask
+    action :update
+  end
+end

--- a/providers/install_global.rb
+++ b/providers/install_global.rb
@@ -27,69 +27,51 @@ action :update do
 end
 
 def install_global_install
-  dev = new_resource.dev ? '--dev' : '--no-dev'
-  quiet = new_resource.quiet ? '--quiet' : ''
-  optimize = new_resource.optimize_autoloader ? optimize_flag(cmd) : ''
+  quiet = '--verbose' #new_resource.quiet ? '--quiet' : ''
+  optimize = new_resource.optimize_autoloader ? '--optimize-autoloader' : ''
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
   prefer_source = new_resource.prefer_source ? '--prefer-source' : ''
+  prefer_stable = new_resource.prefer_stable ? '--prefer-stable' : ''
+  package = new_resource.package
 
-  directory new_resource.install_dir do
-    recursive true
-    user new_resource.user
-    group new_resource.group
-  end
-
-  composer_project new_resource.vendor do
-    project_dir new_resource.install_dir
-    dev new_resource.dev
-    quiet new_resource.quiet
-    optimize new_resource.optimize_autoloader
-    prefer_dist new_resource.prefer_dist
-    prefer_source new_resource.prefer_source
-    user new_resource.user
-    group new_resource.group
-    umask new_resource.umask
-    action :require
-  end
-
-  # Set the bin_dir for completeness
-  execute 'set-bin_dir' do
-    cwd new_resource.install_dir
-    command "#{node['composer']['bin']} config bin-dir #{node['composer']['bin_dir']} #{quiet}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+  execute "composer-install-global-#{package}" do
+    command "#{node['composer']['bin']} global require --no-interaction --no-ansi #{quiet} #{optimize} #{prefer_dist} #{prefer_source} #{prefer_stable} #{package}"
+    environment 'COMPOSER_HOME' => Composer.home_dir(node), 'COMPOSER_BIN_DIR' => Composer.bin_dir(node)
     action :run
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
+    environment "COMPOSER_HOME" => "/home/vagrant"
+    not_if "#{node['composer']['bin']} global show #{new_resource.package}"
   end
-end
 
-def install_global_remove
-  composer_project new_resource.vendor do
-    project_dir new_resource.install_dir
-    dev new_resource.dev
-    quiet new_resource.quiet
-    optimize new_resource.optimize_autoloader
-    prefer_dist new_resource.prefer_dist
-    prefer_source new_resource.prefer_source
-    user new_resource.user
-    group new_resource.group
-    umask new_resource.umask
-    action :remove
-  end
-end
+  # directory new_resource.install_dir do
+  #   recursive true
+  #   user new_resource.user
+  #   group new_resource.group
+  # end
 
-def install_global_update
-  composer_project new_resource.vendor do
-    project_dir new_resource.install_dir
-    dev new_resource.dev
-    quiet new_resource.quiet
-    optimize new_resource.optimize_autoloader
-    prefer_dist new_resource.prefer_dist
-    prefer_source new_resource.prefer_source
-    user new_resource.user
-    group new_resource.group
-    umask new_resource.umask
-    action :update
-  end
+  # composer_project new_resource.vendor do
+  #   project_dir new_resource.install_dir
+  #   dev new_resource.dev
+  #   quiet new_resource.quiet
+  #   optimize new_resource.optimize_autoloader
+  #   prefer_dist new_resource.prefer_dist
+  #   prefer_source new_resource.prefer_source
+  #   user new_resource.user
+  #   group new_resource.group
+  #   umask new_resource.umask
+  #   action :require
+  # end
+
+  # # Set the bin_dir for completeness
+  # execute 'set-bin_dir' do
+  #   cwd new_resource.install_dir
+  #   command "#{node['composer']['bin']} config bin-dir #{node['composer']['bin_dir']} #{quiet}"
+  #   environment 'COMPOSER_HOME' => Composer.home_dir(node)
+  #   action :run
+  #   user new_resource.user
+  #   group new_resource.group
+  #   umask new_resource.umask
+  # end
 end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -46,7 +46,6 @@ def make_execute(cmd)
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -63,7 +62,6 @@ def make_require
     command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -78,7 +76,6 @@ def remove_vendor(cmd)
     command "#{node['composer']['bin']} remove #{vendor}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -44,7 +44,7 @@ def make_execute(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment 'COMPOSER_HOME' => Composer.home_dir(node), 'COMPOSER_BIN_DIR' => Composer.bin_dir(node)
     action :run
     user new_resource.user
     group new_resource.group
@@ -60,7 +60,7 @@ def make_require
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment 'COMPOSER_HOME' => Composer.home_dir(node), 'COMPOSER_BIN_DIR' => Composer.bin_dir(node)
     action :run
     user new_resource.user
     group new_resource.group
@@ -74,7 +74,7 @@ def remove_vendor(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} remove #{vendor}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment 'COMPOSER_HOME' => Composer.home_dir(node), 'COMPOSER_BIN_DIR' => Composer.bin_dir(node)
     action :run
   end
 end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -73,7 +73,7 @@ def remove_vendor(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{vendor}"
+    command "#{node['composer']['bin']} remove #{vendor} --update-with-dependencies"
     environment 'COMPOSER_HOME' => Composer.home_dir(node), 'COMPOSER_BIN_DIR' => Composer.bin_dir(node)
     action :run
   end

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -1,0 +1,3 @@
+include_recipe "composer::default"
+
+composer_install_global "drush/drush"

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: composer
+# Resource:: install_global
+#
+# Copyright 2012-2014, Escape Studios
+#
+
+actions :install, :update, :remove
+default_action :install
+
+attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
+attribute :install_dir, :kind_of => String
+attribute :path, :kind_of => String, :default => nil
+attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :user, :kind_of => String, :default => 'root'
+attribute :group, :kind_of => String, :default => 'root'
+attribute :umask, :kind_of => [String, Fixnum], :default => 0002
+
+def initialize(*args)
+  super
+  @action = :install
+end

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -8,14 +8,14 @@
 actions :install, :update, :remove
 default_action :install
 
-attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
-attribute :install_dir, :kind_of => String
+attribute :package, :kind_of => String, :name_attribute => true, :required => true
+attribute :install_dir, :kind_of => String #TODO: what to do with this? Can be driven by COMPOSER_HOME
 attribute :path, :kind_of => String, :default => nil
-attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_stable, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :user, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
 attribute :umask, :kind_of => [String, Fixnum], :default => 0002

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -10,7 +10,6 @@ default_action :install
 
 attribute :project_dir, :kind_of => String, :required => true
 attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
-attribute :path, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -8,7 +8,7 @@
 actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
-attribute :project_dir, :kind_of => String, :name_attribute => true
+attribute :project_dir, :kind_of => String, :required => true
 attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
 attribute :path, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Add a second resource for a global install to remove all the code in all the other cookbooks with a simple resource call. Also updates to the project resource have been made as bugfixes or to make this possible.
