### PR TITLE
Improvements to composer_project resource

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -31,7 +31,7 @@ action :dump_autoload do
 end
 
 action :remove do
-  remove_vendor 'remove'
+  remove_package 'remove'
 end
 
 def make_execute(cmd)
@@ -54,32 +54,32 @@ end
 
 def make_require
   dev = new_resource.dev ? '--dev' : '--update-no-dev'
-  vendor = new_resource.vendor
-  raise 'vendor is needed for composer_project with action require' if vendor.nil?
+  package = new_resource.package
+  raise 'package is needed for composer_project with action require' if package.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
+    command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{vendor}"
+    not_if "#{node['composer']['bin']} show #{package}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
   end
 end
 
-def remove_vendor(cmd)
-  vendor = new_resource.vendor
-  raise 'vendor is needed for composer_project with action require' if vendor.nil?
+def remove_package(cmd)
+  package = new_resource.package
+  raise 'package is needed for composer_project with action require' if package.nil?
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{vendor}"
+    command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{vendor}"
+    only_if "#{node['composer']['bin']} show #{package}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -46,7 +46,6 @@ def make_execute(cmd)
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -63,7 +62,7 @@ def make_require
     command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
+    not_if "#{node['composer']['bin']} show #{vendor}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -78,7 +77,7 @@ def remove_vendor(cmd)
     command "#{node['composer']['bin']} remove #{vendor}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
+    only_if "#{node['composer']['bin']} show #{vendor}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -55,6 +55,7 @@ end
 def make_require
   dev = new_resource.dev ? '--dev' : '--update-no-dev'
   vendor = new_resource.vendor
+  raise 'vendor is needed for composer_project with action require' if vendor.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
 
   execute 'Install-composer-for-single-project' do
@@ -71,6 +72,7 @@ end
 
 def remove_vendor(cmd)
   vendor = new_resource.vendor
+  raise 'vendor is needed for composer_project with action require' if vendor.nil?
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -63,7 +63,7 @@ def make_require
     command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{package}"
+    not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -79,7 +79,7 @@ def remove_package(cmd)
     command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{package}"
+    only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -63,7 +63,10 @@ def make_require
     command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
+    not_if do
+        !new_resource.version.include?('*') &&
+        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
+      end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -60,7 +60,7 @@ def make_require
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
+    command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
@@ -76,7 +76,7 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
+    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -81,7 +81,7 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
+    command "#{node['composer']['bin']} remove #{package}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{version}"

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -64,9 +64,9 @@ def make_require
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     not_if do
-        !new_resource.version.include?('*') &&
+      !new_resource.version.include?('*') &&
         shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
-      end
+    end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -57,6 +57,7 @@ def make_require
   package = new_resource.package
   raise 'package is needed for composer_project with action require' if package.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
+  version = new_resource.version ? new_resource.version : '*.*.*'
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
@@ -65,7 +66,7 @@ def make_require
     action :run
     not_if do
       !new_resource.version.include?('*') &&
-        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
+        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{version}").exitstatus == 0
     end
     user new_resource.user
     group new_resource.group
@@ -76,13 +77,14 @@ end
 def remove_package(cmd)
   package = new_resource.package
   raise 'package is needed for composer_project with action require' if package.nil?
+  version = new_resource.version ? new_resource.version : '*.*.*'
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
+    only_if "#{node['composer']['bin']} show #{package} #{version}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -65,7 +65,7 @@ def make_require
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     not_if do
-      !new_resource.version.include?('*') &&
+      !version.include?('*') &&
         shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{version}").exitstatus == 0
     end
     user new_resource.user

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -10,7 +10,7 @@ default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
 attribute :package, :kind_of => String, :default => nil
-attribute :version, :kind_of => String, :default => '*.*.*'
+attribute :version, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,7 +9,7 @@ actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
-attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
+attribute :vendor, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -10,7 +10,6 @@ default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
 attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
-attribute :path, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,7 +9,8 @@ actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
-attribute :vendor, :kind_of => String, :default => nil
+attribute :package, :kind_of => String, :default => nil
+attribute :version, :kind_of => String, :default => '*.*.*'
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Hi,

This bundles some improvements to the composer_project resource:
- Vendor shouldn't be required, except for require/remove, it definitely shouldn't be the name attribute, that is the folder
- Removed path attribute, it is never used anyway
- Improved idempotency. Until now the guards were used to check for composer presence, that shouldn't be done. This way installs will fail silently when composer isn't present. Guards are only there for idempotency, I have added that so require/remove are only run when needed. If you don't specify a version number and use \* in it, it will update. Other types of require where you'd expect an update, won't work. It can easily be adapted to include ~ and ^ as items to don't apply the guard.
- Split vendor into package and version. Vendor was the wrong name anyway, vendor is just the first part of the package name. Splitting version allows for decent idempotency checks.

Please let me know what you think.
