### PR TITLE
Feature/provider global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,30 @@ This cookbook includes an LWRP for managing a Composer project
 ### `composer_project`
 
 #### Actions
-- :install: Reads the composer.json file from the current directory, resolves the dependencies, and installs them into vendor - this is the default action
-- :require Create composer.json file using specified vendor and downloads vendor.
+- :install: Reads the composer.json file from the current directory, resolves the dependencies, and installs them into project directory - this is the default action
+- :require Create composer.json file using specified package and version and installs it with the dependencies.
 - :update: Gets the latest versions of the dependencies and updates the composer.lock file
 - :dump_autoload: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
-- :remove Removes vendor from composer.json and uninstalls
+- :remove Removes package from composer.json and uninstalls
 
 #### Attribute parameters
-- project_dir: The directory where your project's composer.json can be found
+- project_dir: The directory where your project's composer.json can be found (name attribute)
+- package: The package to require or remove when using those actions
+- version: The version of the package to require or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
+- vendor: Can be used to combine package and version, deprecated!
 - dev: Install packages listed in require-dev, default false
 - quiet: Do not output any message, default true
 - optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
+- prefer_dist: use the dist installation method
+- prefer_source: use the source installation method
+- bin_dir, overwrites the composer bin dir
+- user: the user to use when executing the composer commands
+- group: the group to use when executing the composer commands
+- umask: the umask to use when executing the composer commands
 
 #### Examples
 ```
-#install project vendors
+# Install the project dependencies
 composer_project "/path/to/project" do
     dev false
     quiet true
@@ -65,31 +74,33 @@ composer_project "/path/to/project" do
     action :install
 end
 
-#require project vendor
+# Require the package in the project dir
 composer_project "/path/to/project" do
+    package 'vendor/package'
+    version '*.*.*'
     dev false
     quiet true
     prefer_dist false
     action :require
 end
 
-#update project vendors
+# Update the project dependencies
 composer_project "/path/to/project" do
     dev false
     quiet true
     action :update
 end
 
-#dump-autoload for project
+# Dump-autoload in the project dir
 composer_project "/path/to/project" do
     dev false
     quiet true
     action :dump_autoload
 end
 
-#remove project vendor
+# Remove the package in the project dir
 composer_project "/path/to/project" do
-    vendor 'repo/vendor'
+    package 'vendor/package'
     action :remove
 end
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ http://getcomposer.org/
 * `node['composer']['global_configs']` - Hash with global config options for users, eg. { "userX" => { "github-oauth" => { "github.com" => "userX_oauth_token" }, "vendor-dir" => "myvendordir" } } - default {}
 * `node['composer']['home_dir']` - COMPOSER_HOME, defaults to nil (in which case install_dir will be used), please do read the [Composer documentation on COMPOSER_HOME](https://getcomposer.org/doc/03-cli.md#composer-home) when setting a custom home_dir
 * `node['composer']['php_recipe']` - The php recipe to include, defaults to "php::default"
+* `node['composer']['global_install']['install_dir']` - The default location to install the packages in for composer_install_global
+* `node['composer']['global_install']['bin_dir']` - The default location to symlink the binaries when using composer_install_global
 
 ## Resources / Providers
 This cookbook includes an LWRP for managing a Composer project and one for a global installation of composer packages

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ http://getcomposer.org/
 * `node['composer']['php_recipe']` - The php recipe to include, defaults to "php::default"
 
 ## Resources / Providers
-This cookbook includes an LWRP for managing a Composer project
+This cookbook includes an LWRP for managing a Composer project and one for a global installation of composer packages
 
 ### `composer_project`
 
@@ -47,7 +47,7 @@ This cookbook includes an LWRP for managing a Composer project
 - :require Create composer.json file using specified package and version and installs it with the dependencies.
 - :update: Gets the latest versions of the dependencies and updates the composer.lock file
 - :dump_autoload: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
-- :remove Removes package from composer.json and uninstalls
+- :remove Removes package from composer.json and uninstalls it
 
 #### Attribute parameters
 - project_dir: The directory where your project's composer.json can be found (name attribute)
@@ -101,6 +101,43 @@ end
 # Remove the package in the project dir
 composer_project "/path/to/project" do
     package 'vendor/package'
+    action :remove
+end
+```
+
+### `composer_install_global`
+
+#### Actions
+- :install: Installs the package in the preferred global composer directory, putting binary symlinks in the preferred global binary directory (see attributes)
+- :update: Gets the latest versions of the dependencies and updates the composer.lock file for the globally installed composer packages
+- :remove Removes package from the global composer.json and uninstalls it
+
+#### Attribute parameters
+- package: The package to install or remove, name_attribute
+- version: The version of the package to install or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
+- install_dir: the directory in which to make the global installation, default: see the attributes
+- bin_dir: the directory in which to make the symlinks to the binaries, default: see the attributes
+- dev: Install packages listed in require-dev, default false
+- quiet: Do not output any message, default true
+- optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
+- prefer_dist: use the dist installation method
+- prefer_source: use the source installation method
+
+#### Examples
+```
+# Install a package globally
+composer_install_global "package" do
+    version '~4.1'
+    action :install
+end
+
+# Update the package
+composer_install_global "package" do
+    action :update
+end
+
+# Remove the package from the global installation
+composer_install_global "package" do
     action :remove
 end
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,8 @@ if node['platform'] == 'windows'
   default['composer']['url'] = 'https://getcomposer.org/Composer-Setup.exe'
   default['composer']['install_dir'] = 'C:\\ProgramData\\ComposerSetup'
   default['composer']['bin'] = "#{node['composer']['install_dir']}\\composer.bat"
+  default['composer']['global_install']['install_dir'] = 'C:\\Program\ Files\\Composer'
+  default['composer']['global_install']['bin_dir'] = 'C:\\ProgramData\\Composer'
 else
   default['composer']['url'] = 'http://getcomposer.org/composer.phar'
   default['composer']['install_dir'] = '/usr/local/bin'
@@ -18,6 +20,8 @@ else
   default['composer']['install_globally'] = true
   default['composer']['mask'] = 0755
   default['composer']['link_type'] = :symbolic
+  default['composer']['global_install']['install_dir'] = '/usr/local/composer'
+  default['composer']['global_install']['bin_dir'] = '/usr/local/bin'
 end
 
 default['composer']['global_configs'] = {}

--- a/providers/install_global.rb
+++ b/providers/install_global.rb
@@ -32,7 +32,8 @@ def install_global_install
   directory install_dir
 
   composer_project install_dir do
-    vendor new_resource.package
+    package new_resource.package
+    version new_resource.version
     bin_dir bin_dir
     dev new_resource.dev
     quiet new_resource.quiet
@@ -47,7 +48,8 @@ def install_global_remove
   install_dir = new_resource.install_dir ? new_resource.install_dir : node['composer']['global_install']['install_dir']
 
   composer_project install_dir do
-    vendor new_resource.package
+    package new_resource.package
+    version new_resource.version
     bin_dir bin_dir
     dev new_resource.dev
     quiet new_resource.quiet

--- a/providers/install_global.rb
+++ b/providers/install_global.rb
@@ -59,3 +59,20 @@ def install_global_remove
     action :remove
   end
 end
+
+def install_global_update
+  install_dir = new_resource.install_dir ? new_resource.install_dir : node['composer']['global_install']['install_dir']
+  bin_dir = new_resource.bin_dir ? new_resource.bin_dir : node['composer']['global_install']['bin_dir']
+
+  composer_project install_dir do
+    package new_resource.package
+    version new_resource.version
+    bin_dir bin_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize_autoloader new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    action :update
+  end
+end

--- a/providers/install_global.rb
+++ b/providers/install_global.rb
@@ -1,0 +1,59 @@
+#
+# Cookbook Name:: composer
+# Resource:: install_global
+#
+# Copyright 2012-2014, Escape Studios
+#
+
+use_inline_resources if defined?(use_inline_resources)
+
+def whyrun_supported?
+  true
+end
+
+action :install do
+  install_global_install
+  new_resource.updated_by_last_action(true)
+end
+
+action :remove do
+  install_global_remove
+  new_resource.updated_by_last_action(true)
+end
+
+action :update do
+  install_global_update
+  new_resource.updated_by_last_action(true)
+end
+
+def install_global_install
+  install_dir = new_resource.install_dir ? new_resource.install_dir : node['composer']['global_install']['install_dir']
+  bin_dir = new_resource.bin_dir ? new_resource.bin_dir : node['composer']['global_install']['bin_dir']
+  directory install_dir
+
+  composer_project install_dir do
+    vendor new_resource.package
+    bin_dir bin_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize_autoloader new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    action :require
+  end
+end
+
+def install_global_remove
+  install_dir = new_resource.install_dir ? new_resource.install_dir : node['composer']['global_install']['install_dir']
+
+  composer_project install_dir do
+    vendor new_resource.package
+    bin_dir bin_dir
+    dev new_resource.dev
+    quiet new_resource.quiet
+    optimize_autoloader new_resource.optimize_autoloader
+    prefer_dist new_resource.prefer_dist
+    prefer_source new_resource.prefer_source
+    action :remove
+  end
+end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -31,7 +31,7 @@ action :dump_autoload do
 end
 
 action :remove do
-  remove_vendor 'remove'
+  remove_package 'remove'
 end
 
 def make_execute(cmd)
@@ -54,32 +54,32 @@ end
 
 def make_require
   dev = new_resource.dev ? '--dev' : '--update-no-dev'
-  vendor = new_resource.vendor
-  raise 'vendor is needed for composer_project with action require' if vendor.nil?
+  package = new_resource.package
+  raise 'package is needed for composer_project with action require' if package.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
+    command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{vendor}"
+    not_if "#{node['composer']['bin']} show #{package}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
   end
 end
 
-def remove_vendor(cmd)
-  vendor = new_resource.vendor
-  raise 'vendor is needed for composer_project with action require' if vendor.nil?
+def remove_package(cmd)
+  package = new_resource.package
+  raise 'package is needed for composer_project with action require' if package.nil?
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{vendor}"
+    command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{vendor}"
+    only_if "#{node['composer']['bin']} show #{package}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -49,10 +49,6 @@ def make_execute(cmd)
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
     )
     action :run
-    not_if do
-        !new_resource.version.include?('*') &&
-        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
-      end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -46,7 +46,6 @@ def make_execute(cmd)
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -63,7 +62,7 @@ def make_require
     command "#{node['composer']['bin']} require #{vendor} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
+    not_if "#{node['composer']['bin']} show #{vendor}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -78,7 +77,7 @@ def remove_vendor(cmd)
     command "#{node['composer']['bin']} remove #{vendor}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if 'which composer'
+    only_if "#{node['composer']['bin']} show #{vendor}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -30,7 +30,7 @@ action :dump_autoload do
   new_resource.updated_by_last_action(true)
 end
 
-action :remo§ do
+action :remove do
   remove_package 'remove'
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -55,6 +55,7 @@ end
 def make_require
   dev = new_resource.dev ? '--dev' : '--update-no-dev'
   vendor = new_resource.vendor
+  raise 'vendor is needed for composer_project with action require' if vendor.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
 
   execute 'Install-composer-for-single-project' do
@@ -71,6 +72,7 @@ end
 
 def remove_vendor(cmd)
   vendor = new_resource.vendor
+  raise 'vendor is needed for composer_project with action require' if vendor.nil?
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -63,7 +63,7 @@ def make_require
     command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{package}"
+    not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
     user new_resource.user
     group new_resource.group
     umask new_resource.umask
@@ -79,7 +79,7 @@ def remove_package(cmd)
     command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{package}"
+    only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
   end
 end
 

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -49,6 +49,10 @@ def make_execute(cmd)
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
     })
     action :run
+    not_if do
+        !new_resource.version.include?('*') &&
+        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
+      end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -63,7 +63,10 @@ def make_require
     command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
+    not_if do
+        !new_resource.version.include?('*') &&
+        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
+      end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -60,7 +60,7 @@ def make_require
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} require #{package}#{new_resource.version} #{dev} #{prefer_dist}"
+    command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     not_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
@@ -76,7 +76,7 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{package}#{new_resource.version}"
+    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -81,7 +81,7 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
+    command "#{node['composer']['bin']} remove #{package}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{version}"

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -44,7 +44,7 @@ def make_execute(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
-    environment ({
+    environment({
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
     })
@@ -69,7 +69,7 @@ def make_require
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
-    environment ({
+    environment({
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
     })
@@ -91,8 +91,13 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
+<<<<<<< 639077b6a794ec77195371efebfad1c6af5b2e58
     command "#{node['composer']['bin']} remove #{package}"
     environment ({
+=======
+    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
+    environment({
+>>>>>>> Fix syntax errors
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
     })

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -71,7 +71,7 @@ def make_require
     )
     action :run
     not_if do
-      !new_resource.version.include?('*') &&
+      !version.include?('*') &&
         shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{version}").exitstatus == 0
     end
     user new_resource.user

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -44,10 +44,10 @@ def make_execute(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
-    environment({
+    environment(
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
-    })
+    )
     action :run
     not_if do
         !new_resource.version.include?('*') &&
@@ -69,10 +69,10 @@ def make_require
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
-    environment({
+    environment(
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
-    })
+    )
     action :run
     not_if do
       !new_resource.version.include?('*') &&
@@ -91,16 +91,11 @@ def remove_package(cmd)
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-<<<<<<< 639077b6a794ec77195371efebfad1c6af5b2e58
     command "#{node['composer']['bin']} remove #{package}"
-    environment ({
-=======
-    command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
-    environment({
->>>>>>> Fix syntax errors
+    environment(
       'COMPOSER_HOME' => Composer.home_dir(node),
       'COMPOSER_BIN_DIR' => new_resource.bin_dir
-    })
+    )
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{version}"
   end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -64,9 +64,9 @@ def make_require
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     not_if do
-        !new_resource.version.include?('*') &&
+      !new_resource.version.include?('*') &&
         shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
-      end
+    end
     user new_resource.user
     group new_resource.group
     umask new_resource.umask

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -30,7 +30,7 @@ action :dump_autoload do
   new_resource.updated_by_last_action(true)
 end
 
-action :remove do
+action :remo§ do
   remove_package 'remove'
 end
 
@@ -44,7 +44,10 @@ def make_execute(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment ({
+      'COMPOSER_HOME' => Composer.home_dir(node),
+      'COMPOSER_BIN_DIR' => new_resource.bin_dir
+    })
     action :run
     user new_resource.user
     group new_resource.group
@@ -62,7 +65,10 @@ def make_require
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} require #{package}:#{new_resource.version} #{dev} #{prefer_dist}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment ({
+      'COMPOSER_HOME' => Composer.home_dir(node),
+      'COMPOSER_BIN_DIR' => new_resource.bin_dir
+    })
     action :run
     not_if do
       !new_resource.version.include?('*') &&
@@ -82,7 +88,10 @@ def remove_package(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} remove #{package}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment ({
+      'COMPOSER_HOME' => Composer.home_dir(node),
+      'COMPOSER_BIN_DIR' => new_resource.bin_dir
+    })
     action :run
     only_if "#{node['composer']['bin']} show #{package} #{version}"
   end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -57,6 +57,7 @@ def make_require
   package = new_resource.package
   raise 'package is needed for composer_project with action require' if package.nil?
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
+  version = new_resource.version ? new_resource.version : '*.*.*'
 
   execute 'Install-composer-for-single-project' do
     cwd new_resource.project_dir
@@ -65,7 +66,7 @@ def make_require
     action :run
     not_if do
       !new_resource.version.include?('*') &&
-        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{new_resource.version}").exitstatus == 0
+        shell_out("cd #{new_resource.project_dir} && #{node['composer']['bin']} show #{package} #{version}").exitstatus == 0
     end
     user new_resource.user
     group new_resource.group
@@ -76,13 +77,14 @@ end
 def remove_package(cmd)
   package = new_resource.package
   raise 'package is needed for composer_project with action require' if package.nil?
+  version = new_resource.version ? new_resource.version : '*.*.*'
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} remove #{package}:#{new_resource.version}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
-    only_if "#{node['composer']['bin']} show #{package} #{new_resource.version}"
+    only_if "#{node['composer']['bin']} show #{package} #{version}"
   end
 end
 

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -9,6 +9,7 @@ actions :install, :update, :remove
 default_action :install
 
 attribute :package, :kind_of => String, :name_attribute => true, :required => true
+attribute :version, :kind_of => String, :default => '*.*.*'
 attribute :install_dir, :kind_of => String, :default => nil
 attribute :bin_dir, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: composer
+# Resource:: install_global
+#
+# Copyright 2012-2014, Escape Studios
+#
+
+actions :install, :update, :remove
+default_action :install
+
+attribute :package, :kind_of => String, :name_attribute => true, :required => true
+attribute :install_dir, :kind_of => String, :default => nil
+attribute :bin_dir, :kind_of => String, :default => nil
+attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_stable, :kind_of => [TrueClass, FalseClass], :default => false
+
+def initialize(*args)
+  super
+  @action = :install
+end

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -17,7 +17,6 @@ attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :prefer_stable, :kind_of => [TrueClass, FalseClass], :default => false
 
 def initialize(*args)
   super

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -16,6 +16,7 @@ attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :bin_dir, :kind_of => String, :default => 'vendor/bin'
 attribute :user, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
 attribute :umask, :kind_of => [String, Fixnum], :default => 0002

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,6 +9,7 @@ actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
+attribute :vendor, :kind_of => String, :default => nil
 attribute :package, :kind_of => String, :default => nil
 attribute :version, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -10,7 +10,7 @@ default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
 attribute :package, :kind_of => String, :default => nil
-attribute :version, :kind_of => String, :default => '*.*.*'
+attribute :version, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,7 +9,7 @@ actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
-attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
+attribute :vendor, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -10,7 +10,6 @@ default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
 attribute :vendor, :kind_of => String, :name_attribute => true, :required => true
-attribute :path, :kind_of => String, :default => nil
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,7 +9,8 @@ actions :install, :single, :require, :update, :dump_autoload, :remove
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
-attribute :vendor, :kind_of => String, :default => nil
+attribute :package, :kind_of => String, :default => nil
+attribute :version, :kind_of => String, :default => '*.*.*'
 attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
This gives the easy ability to have global installs. It is still very configurable and just extends composer_project to make global installs easier by default.
This would make the phploc, phpmd, ... cookbooks a lot simpler!

It is based on the other PR (#61) I have opened. Fixes #51 

An example on how it could be used can be seen here: https://github.com/daften/cookbook-phing/tree/feature/composer_install_global
