### PR TITLE
Bugfix for composer_project in vendor support, empty return

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -116,7 +116,7 @@ def vendor_package_identity(vendor, package, version)
               else
                 vendor_split[1]
               end
-
-    return package, version
   end
+
+  return package, version
 end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -118,5 +118,5 @@ def vendor_package_identity(vendor, package, version)
               end
   end
 
-  return package, version
+  [package, version]
 end


### PR DESCRIPTION
There was an error. You changed the if/else to unless, but forgot the general return, this should fix it.
Basically, old stuff was still working, but new stuff wasn't :D