### PR TITLE
Idempotency on linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,9 +14,9 @@ if node['platform'] == 'windows'
   default['composer']['global_install']['install_dir'] = 'C:\\Program\ Files\\Composer'
   default['composer']['global_install']['bin_dir'] = 'C:\\ProgramData\\Composer'
 else
-  default['composer']['version'] = '1.3.2'
+  default['composer']['version'] = '1.4.1'
   default['composer']['url'] = "https://getcomposer.org/download/#{node['composer']['version']}/composer.phar"
-  default['composer']['checksum'] = '6a4f761aa34bb69fca86bc411a5e9836ca8246f0fcd29f3804b174fee9fb0569'
+  default['composer']['checksum'] = 'abd277cc3453be980bb48cbffe9d1f7422ca1ef4bc0b7d035fda87cea4d55cbc'
   default['composer']['install_dir'] = '/usr/local/bin'
   default['composer']['bin'] = "#{node['composer']['install_dir']}/composer"
   default['composer']['install_globally'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,9 @@ if node['platform'] == 'windows'
   default['composer']['global_install']['install_dir'] = 'C:\\Program\ Files\\Composer'
   default['composer']['global_install']['bin_dir'] = 'C:\\ProgramData\\Composer'
 else
-  default['composer']['url'] = 'http://getcomposer.org/composer.phar'
+  default['composer']['version'] = '1.3.2'
+  default['composer']['url'] = "https://getcomposer.org/download/#{node['composer']['version']}/composer.phar"
+  default['composer']['checksum'] = '6a4f761aa34bb69fca86bc411a5e9836ca8246f0fcd29f3804b174fee9fb0569'
   default['composer']['install_dir'] = '/usr/local/bin'
   default['composer']['bin'] = "#{node['composer']['install_dir']}/composer"
   default['composer']['install_globally'] = true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,6 +32,6 @@ else
     checksum node['composer']['checksum']
     mode node['composer']['mask']
     action :create
-    not_if { ::File.exist?(file) }
+    not_if "[[ $(#{file} --version | grep #{node['composer']['version']} | wc -l) -eq 1 ]]"
   end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -29,6 +29,7 @@ else
 
   remote_file file do
     source node['composer']['url']
+    checksum node['composer']['checksum']
     mode node['composer']['mask']
     action :create
     not_if { ::File.exist?(file) }

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'composer::default' do
   before(:each) do
     stub_command("php -m | grep 'Phar'").and_return(true)
+    stub_command('[[ $(/usr/local/bin/composer --version | grep 1.4.1 | wc -l) -eq 1 ]]')
   end
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -4,7 +4,7 @@ set :backend, :exec
 
 # these vars must correspond with attributes' values
 composer_install_path = '/usr/local/bin'
-composer_version = '1.3.2'
+composer_version = '1.4.1'
 
 describe file("#{composer_install_path}/composer") do
   it { should be_file }

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -1,11 +1,17 @@
 require 'serverspec'
 
-describe file('/usr/local/bin/composer') do
+set :backend, :exec
+
+# these vars must correspond with attributes' values
+composer_install_path = '/usr/local/bin'
+composer_version = '1.3.2'
+
+describe file("#{composer_install_path}/composer") do
   it { should be_file }
   it { should be_mode 755 }
 end
 
-describe command('/usr/local/bin/composer') do
+describe command("#{composer_install_path}/composer") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should contain 'Composer version 1.3.2' }
+  its(:stdout) { should contain "Composer version #{composer_version}" }
 end

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -4,3 +4,8 @@ describe file('/usr/local/bin/composer') do
   it { should be_file }
   it { should be_mode 755 }
 end
+
+describe command('/usr/local/bin/composer') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should contain 'Composer version 1.3.2' }
+end


### PR DESCRIPTION
Cookbook used to download latest snapshots of Composer over plain http without veryfying checksum which was vulnerable to MitM attacks.
This PR changes the download URL to specific version (defined in attribute) downloaded via HTTPS and adds checksum verification of the downloaded file.
On the other hand, this requires update every time new stable version of Composer is released if you want to keep installed version up to date but I think it's small price for enhanced security and idempotency of the recipe.