### PR TITLE
Dependency Cleanup

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+group :integration do
+  cookbook 'php'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version (>= 2.4.0) of the compose
 ## Unreleased
 
 - Remove unneeded dependencies on `apt` / `windows` cookbooks for resources now in core Chef
+- Adds testing on Alma / Rocky Linux 8
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file is used to list changes made in each version (>= 2.4.0) of the composer cookbook.
 
+## Unreleased
+
+- Remove unneeded dependencies on `apt` / `windows` cookbooks for resources now in core Chef
+
+### Breaking
+
+- Remove dependency on `php` cookbook
+  - ⚠ This cookbook will no longer install PHP for you!
+  - Use e.g. the `php` cookbook directly to install PHP before including these recipes
+
 ## 2.8.0 (2021-12-15)
 
 - Chef 17 compatibility: enable `unified_mode` for custom resources

--- a/README.md
+++ b/README.md
@@ -1,162 +1,165 @@
-[![Build Status](https://travis-ci.org/djoos-cookbooks/composer.png)](https://travis-ci.org/djoos-cookbooks/composer)
+# `composer` cookbook
 
-# composer cookbook
-
-## Description
+## Description
 
 This cookbook provides an easy way to install Composer, a dependency manager for PHP.
 
-More information?
-http://getcomposer.org/
+More information available at <http://getcomposer.org/>.
 
-## Requirements
+## Requirements
 
 ### Cookbooks:
 
-* php
-* windows
+- php
 
 ### Platforms:
 
-* Ubuntu
-* Debian
-* RHEL
-* CentOS
-* Fedora
-* Windows
+- Ubuntu
+- Debian
+- RHEL
+- CentOS
+- Fedora
+- Windows
 
-## Attributes
+## Attributes
 
-* `node['composer']['url']` - Location of the source
-* `node['composer']['install_dir']` - Installation target directory (absolute or relative path) if installing locally
-* `node['composer']['bin']` - bin directory
-* `node['composer']['install_globally']` - Installation method, ':source' or ':package' - default true
-* `node['composer']['mask']` - Mask for composer.phar - 0755
-* `node['composer']['link_type']` - link type for composer.phar link - default :symbolic
-* `node['composer']['global_configs']` - Hash with global config options for users, eg. { "userX" => { "github-oauth" => { "github.com" => "userX_oauth_token" }, "vendor-dir" => "myvendordir" } } - default {}
-* `node['composer']['home_dir']` - COMPOSER_HOME, defaults to nil (in which case install_dir will be used), please do read the [Composer documentation on COMPOSER_HOME](https://getcomposer.org/doc/03-cli.md#composer-home) when setting a custom home_dir
-* `node['composer']['php_recipe']` - The php recipe to include, defaults to "php::default"
-* `node['composer']['global_install']['install_dir']` - The default location to install the packages in for composer_install_global
-* `node['composer']['global_install']['bin_dir']` - The default location to symlink the binaries when using composer_install_global
+- `node['composer']['url']` - Location of the source
+- `node['composer']['install_dir']` - Installation target directory (absolute or relative path) if installing locally
+- `node['composer']['bin']` - bin directory
+- `node['composer']['install_globally']` - Installation method, `:source` or `:package` - default `true`
+- `node['composer']['mask']` - Mask for composer.phar - default `0755`
+- `node['composer']['link_type']` - link type for composer.phar link - default `:symbolic`
+- `node['composer']['global_configs']` - Hash with global config options for users, eg. `{ "userX" => { "github-oauth" => { "github.com" => "userX_oauth_token" }, "vendor-dir" => "myvendordir" } }` - default `{}`
+- `node['composer']['home_dir']` - COMPOSER_HOME, defaults to nil (in which case install_dir will be used), please do read the [Composer documentation on COMPOSER_HOME](https://getcomposer.org/doc/03-cli.md#composer-home) when setting a custom home_dir
+- `node['composer']['php_recipe']` - The php recipe to include, defaults to `php::default`
+- `node['composer']['global_install']['install_dir']` - The default location to install the packages in for `composer_install_global`
+- `node['composer']['global_install']['bin_dir']` - The default location to symlink the binaries when using `composer_install_global`
 
-## Resources / Providers
-This cookbook includes an LWRP for managing a Composer project and one for a global installation of composer packages
+## Resources / Providers
+
+This cookbook includes resources for managing a Composer project locally and installing Composer packages globally
 
 ### `composer_project`
 
 #### Actions
-- :install: Reads the composer.json file from the current directory, resolves the dependencies, and installs them into project directory - this is the default action
-- :require Create composer.json file using specified package and version and installs it with the dependencies.
-- :update: Gets the latest versions of the dependencies and updates the composer.lock file
-- :dump_autoload: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
-- :remove Removes package from composer.json and uninstalls it
+
+- `:install`: Reads the composer.json file from the current directory, resolves the dependencies, and installs them into project directory - this is the default action
+- `:require`: Create composer.json file using specified package and version and installs it with the dependencies.
+- `:update`: Gets the latest versions of the dependencies and updates the composer.lock file
+- `:dump_autoload`: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
+- `:remove`: Removes package from composer.json and uninstalls it
 
 #### Attribute parameters
-- project_dir: The directory where your project's composer.json can be found (name attribute)
-- package: The package to require or remove when using those actions
-- version: The version of the package to require or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
-- vendor: Can be used to combine package and version, deprecated!
-- dev: Install packages listed in require-dev, default false
-- quiet: Do not output any message, default true
-- optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
-- prefer_dist: use the dist installation method
-- prefer_source: use the source installation method
-- bin_dir, overwrites the composer bin dir
-- user: the user to use when executing the composer commands
-- group: the group to use when executing the composer commands
-- umask: the umask to use when executing the composer commands
-- environment: A hash of environment variables that will be available when running composer
+
+- `project_dir`: The directory where your project's composer.json can be found (name attribute)
+- `package`: The package to require or remove when using those actions
+- `version`: The version of the package to require or remove when using those actions, default `*.*.*` Be careful when uninstalling, the version has to match the installed package!
+- `vendor`: Can be used to combine package and version, deprecated!
+- `dev`: Install packages listed in require-dev, default `false`
+- `quiet`: Do not output any message, default `true`
+- `optimize_autoloader`: Optimize PSR0 packages to use classmaps, default `false`
+- `prefer_dist`: use the dist installation method
+- `prefer_source`: use the source installation method
+- `bin_dir`:, overwrites the composer bin dir
+- `user`: the user to use when executing the composer commands
+- `group`: the group to use when executing the composer commands
+- `umask`: the umask to use when executing the composer commands
+- `environment`: A hash of environment variables that will be available when running composer
 
 #### Examples
-```
+
+```rb
 # Install the project dependencies
 composer_project "/path/to/project" do
-    dev false
-    quiet true
-    prefer_dist false
-    action :install
+  dev false
+  quiet true
+  prefer_dist false
+  action :install
 end
 
 # Require the package in the project dir
 composer_project "/path/to/project" do
-    package 'vendor/package'
-    version '*.*.*'
-    dev false
-    quiet true
-    prefer_dist false
-    action :require
+  package 'vendor/package'
+  version '*.*.*'
+  dev false
+  quiet true
+  prefer_dist false
+  action :require
 end
 
 # Update the project dependencies
 composer_project "/path/to/project" do
-    dev false
-    quiet true
-    action :update
+  dev false
+  quiet true
+  action :update
 end
 
 # Dump-autoload in the project dir
 composer_project "/path/to/project" do
-    dev false
-    quiet true
-    action :dump_autoload
+  dev false
+  quiet true
+  action :dump_autoload
 end
 
 # Remove the package in the project dir
 composer_project "/path/to/project" do
-    package 'vendor/package'
-    action :remove
+  package 'vendor/package'
+  action :remove
 end
 ```
 
 ### `composer_install_global`
 
 #### Actions
-- :install: Installs the package in the preferred global composer directory, putting binary symlinks in the preferred global binary directory (see attributes)
-- :update: Gets the latest versions of the dependencies and updates the composer.lock file for the globally installed composer packages
-- :remove Removes package from the global composer.json and uninstalls it
+
+- `:install`: Installs the package in the preferred global composer directory, putting binary symlinks in the preferred global binary directory (see attributes)
+- `:update`: Gets the latest versions of the dependencies and updates the composer.lock file for the globally installed composer packages
+- `:remove`: Removes package from the global composer.json and uninstalls it
 
 #### Attribute parameters
-- package: The package to install or remove, name_attribute
-- version: The version of the package to install or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
-- install_dir: the directory in which to make the global installation, default: see the attributes
-- bin_dir: the directory in which to make the symlinks to the binaries, default: see the attributes
-- dev: Install packages listed in require-dev, default false
-- quiet: Do not output any message, default true
-- optimize_autoloader: Optimize PSR0 packages to use classmaps, default false
-- prefer_dist: use the dist installation method
-- prefer_source: use the source installation method
+
+- `package`: The package to install or remove, name_attribute
+- `version`: The version of the package to install or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
+- `install_dir`: the directory in which to make the global installation, default: see the attributes
+- `bin_dir`: the directory in which to make the symlinks to the binaries, default: see the attributes
+- `dev`: Install packages listed in require-dev, default false
+- `quiet`: Do not output any message, default true
+- `optimize_autoloader`: Optimize PSR0 packages to use classmaps, default false
+- `prefer_dist`: use the dist installation method
+- `prefer_source`: use the source installation method
 
 #### Examples
-```
+
+```rb
 # Install a package globally
 composer_install_global "package" do
-    version '~4.1'
-    action :install
+  version '~4.1'
+  action :install
 end
 
 # Update the package
 composer_install_global "package" do
-    action :update
+  action :update
 end
 
 # Remove the package from the global installation
 composer_install_global "package" do
-    action :remove
+  action :remove
 end
 ```
 
-## Usage
+## Usage
 
 1. include `recipe[composer]` in a run list
 2. tweak the attributes via attributes/default.rb
 --- OR ---
 [override the attribute on a higher level](http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
 
-## References
+## References
 
-* [Composer home page] (http://getcomposer.org/)
+- [Composer home page](http://getcomposer.org/)
 
-## License and Authors
+## License and Authors
 
 Author: David Joos <development@davidjoos.com>
 Copyright: 2016-2017, David Joos

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ More information available at <http://getcomposer.org/>.
 
 ## Requirements
 
+⚠ This cookbook does not install PHP! Please make sure PHP is installed before this cookbook is included, e.g. by using the [`php` cookbook](https://github.com/sous-chefs/php).
+
 ### Cookbooks:
 
-- php
+No dependencies.
 
 ### Platforms:
 
@@ -31,40 +33,43 @@ More information available at <http://getcomposer.org/>.
 - `node['composer']['link_type']` - link type for composer.phar link - default `:symbolic`
 - `node['composer']['global_configs']` - Hash with global config options for users, eg. `{ "userX" => { "github-oauth" => { "github.com" => "userX_oauth_token" }, "vendor-dir" => "myvendordir" } }` - default `{}`
 - `node['composer']['home_dir']` - COMPOSER_HOME, defaults to nil (in which case install_dir will be used), please do read the [Composer documentation on COMPOSER_HOME](https://getcomposer.org/doc/03-cli.md#composer-home) when setting a custom home_dir
-- `node['composer']['php_recipe']` - The php recipe to include, defaults to `php::default`
 - `node['composer']['global_install']['install_dir']` - The default location to install the packages in for `composer_install_global`
 - `node['composer']['global_install']['bin_dir']` - The default location to symlink the binaries when using `composer_install_global`
 
-## Resources / Providers
+## Resources
 
-This cookbook includes resources for managing a Composer project locally and installing Composer packages globally
+This cookbook includes resources for managing a Composer project and for installing Composer packages globally:
 
 ### `composer_project`
 
 #### Actions
 
-- `:install`: Reads the composer.json file from the current directory, resolves the dependencies, and installs them into project directory - this is the default action
-- `:require`: Create composer.json file using specified package and version and installs it with the dependencies.
-- `:update`: Gets the latest versions of the dependencies and updates the composer.lock file
-- `:dump_autoload`: Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)
-- `:remove`: Removes package from composer.json and uninstalls it
+| Action           | Description                                                                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:install`       | Reads the composer.json file from the current directory, resolves the dependencies, and installs them into project directory - this is the default action |
+| `:require`       | Create composer.json file using specified package and version and installs it with the dependencies.                                                      |
+| `:update`        | Gets the latest versions of the dependencies and updates the composer.lock file                                                                           |
+| `:dump_autoload` | Updates the autoloader without having to go through an install or update (eg. because of new classes in a classmap package)                               |
+| `:remove`        | Removes package from composer.json and uninstalls it                                                                                                      |
 
-#### Attribute parameters
+#### Properties
 
-- `project_dir`: The directory where your project's composer.json can be found (name attribute)
-- `package`: The package to require or remove when using those actions
-- `version`: The version of the package to require or remove when using those actions, default `*.*.*` Be careful when uninstalling, the version has to match the installed package!
-- `vendor`: Can be used to combine package and version, deprecated!
-- `dev`: Install packages listed in require-dev, default `false`
-- `quiet`: Do not output any message, default `true`
-- `optimize_autoloader`: Optimize PSR0 packages to use classmaps, default `false`
-- `prefer_dist`: use the dist installation method
-- `prefer_source`: use the source installation method
-- `bin_dir`:, overwrites the composer bin dir
-- `user`: the user to use when executing the composer commands
-- `group`: the group to use when executing the composer commands
-- `umask`: the umask to use when executing the composer commands
-- `environment`: A hash of environment variables that will be available when running composer
+| Name                  | Description                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `project_dir`         | The directory where your project's composer.json can be found (name attribute)                                                                                           |
+| `package`             | The package to require or remove when using those actions                                                                                                                |
+| `version`             | The version of the package to require or remove when using those actions, default `*.*.*`. Be careful when uninstalling, the version has to match the installed package! |
+| `vendor`              | Can be used to combine package and version, deprecated!                                                                                                                  |
+| `dev`                 | Install packages listed in require-dev, default `false`                                                                                                                  |
+| `quiet`               | Do not output any message, default `true`                                                                                                                                |
+| `optimize_autoloader` | Optimize PSR0 packages to use classmaps, default `false`                                                                                                                 |
+| `prefer_dist`         | use the dist installation method                                                                                                                                         |
+| `prefer_source`       | use the source installation method                                                                                                                                       |
+| `bin_dir`             | overwrites the composer bin dir                                                                                                                                          |
+| `user`                | the user to use when executing the composer commands                                                                                                                     |
+| `group`               | the group to use when executing the composer commands                                                                                                                    |
+| `umask`               | the umask to use when executing the composer commands                                                                                                                    |
+| `environment`         | A hash of environment variables that will be available when running composer                                                                                             |
 
 #### Examples
 
@@ -112,21 +117,25 @@ end
 
 #### Actions
 
-- `:install`: Installs the package in the preferred global composer directory, putting binary symlinks in the preferred global binary directory (see attributes)
-- `:update`: Gets the latest versions of the dependencies and updates the composer.lock file for the globally installed composer packages
-- `:remove`: Removes package from the global composer.json and uninstalls it
+| Action     | Description                                                                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:install` | Installs the package in the preferred global composer directory, putting binary symlinks in the preferred global binary directory (see attributes) |
+| `:update`  | Gets the latest versions of the dependencies and updates the composer.lock file for the globally installed composer packages                       |
+| `:remove`  | Removes package from the global composer.json and uninstalls it                                                                                    |
 
 #### Attribute parameters
 
-- `package`: The package to install or remove, name_attribute
-- `version`: The version of the package to install or remove when using those actions, default *.*.* Be careful when uninstalling, the version has to match the installed package!
-- `install_dir`: the directory in which to make the global installation, default: see the attributes
-- `bin_dir`: the directory in which to make the symlinks to the binaries, default: see the attributes
-- `dev`: Install packages listed in require-dev, default false
-- `quiet`: Do not output any message, default true
-- `optimize_autoloader`: Optimize PSR0 packages to use classmaps, default false
-- `prefer_dist`: use the dist installation method
-- `prefer_source`: use the source installation method
+| Property              | Description                                                                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `package`             | The package to install or remove, name_attribute                                                                                                                         |
+| `version`             | The version of the package to install or remove when using those actions, default `*.*.*`. Be careful when uninstalling, the version has to match the installed package! |
+| `install_dir`         | the directory in which to make the global installation, default: see the attributes                                                                                      |
+| `bin_dir`             | the directory in which to make the symlinks to the binaries, default: see the attributes                                                                                 |
+| `dev`                 | Install packages listed in require-dev, default `false`                                                                                                                  |
+| `quiet`               | Do not output any message, default `true`                                                                                                                                |
+| `optimize_autoloader` | Optimize PSR0 packages to use classmaps, default `false`                                                                                                                 |
+| `prefer_dist`         | use the dist installation method                                                                                                                                         |
+| `prefer_source`       | use the source installation method                                                                                                                                       |
 
 #### Examples
 
@@ -150,10 +159,10 @@ end
 
 ## Usage
 
-1. include `recipe[composer]` in a run list
-2. tweak the attributes via attributes/default.rb
---- OR ---
-[override the attribute on a higher level](http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
+1. Make sure PHP is installed (e.g. include the `php::default` recipe)
+2. Set custom values for any attributes in a wrapper recipe / node data
+3. Include `composer::default` in your wrapper recipe / run list
+4. Use `composer_project` and `composer_install_global` in your recipes
 
 ## References
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ Contributions to this cookbook will only be accepted if all tests pass successfu
 
 Install the latest stable version of [ChefDK](https://downloads.chef.io/chef-dk/). You'll need [Vagrant](http://www.vagrantup.com/downloads.html) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads) for running integration tests.
 
-## Running tests
+## Running tests
 
 ### Style checks
 
@@ -16,10 +16,10 @@ Install the latest stable version of [ChefDK](https://downloads.chef.io/chef-dk/
 
 `chef exec rake unit`
 
-## Integration tests
+## Integration tests
 
 `chef exec rake integration`
 
-## All checks/tests
+## All checks/tests
 
 `chef exec rake`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Attributes:: default
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 include_attribute 'php'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,8 +5,6 @@
 # Copyright:: 2016-2022, David Joos
 #
 
-include_attribute 'php'
-
 if platform?('windows')
   default['composer']['url'] = 'https://getcomposer.org/Composer-Setup.exe'
   default['composer']['install_dir'] = 'C:\\ProgramData\\ComposerSetup'
@@ -26,5 +24,4 @@ end
 
 default['composer']['global_configs'] = {}
 default['composer']['home_dir'] = nil
-default['composer']['php_recipe'] = 'php::default'
 default['composer']['self_update_channel'] = nil

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -15,6 +15,13 @@ provisioner:
   name: dokken
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: centos-7
     driver:
       image: dokken/centos-7
@@ -42,6 +49,13 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
       pid_one_command: /bin/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,0 +1,58 @@
+---
+driver:
+  name: dokken
+  privileged: true
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
+  cap_add:
+    - SYS_PTRACE
+    - SYS_ADMIN
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+platforms:
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-stream-8
+    driver:
+      image: dokken/centos-stream-8
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /bin/systemd
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: chef
+  product_name: cinc
   chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
@@ -15,8 +15,9 @@ verifier:
 
 platforms:
   - name: centos-7
-  - name: centos-8
+  - name: centos_stream-8
   - name: debian-10
+  - name: debian-11
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,10 +14,12 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: centos_stream-8
   - name: centos-7
   - name: debian-10
   - name: debian-11
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,8 +3,8 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
-  product_name: cinc
+  name: chef_infra
+  product_name: chef
   chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
@@ -14,8 +14,8 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-7
   - name: centos_stream-8
+  - name: centos-7
   - name: debian-10
   - name: debian-11
   - name: ubuntu-18.04
@@ -24,6 +24,7 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[php::default]
       - recipe[composer::default]
     attributes:
       composer:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,13 +6,11 @@ description      'Installs/Configures Composer'
 version          '2.8.0'
 chef_version     '>= 15.3'
 
-%w(debian ubuntu redhat centos fedora scientific amazon windows).each do |os|
+%w(debian ubuntu redhat centos centos_stream fedora scientific amazon windows).each do |os|
   supports os
 end
 
 source_url 'https://github.com/djoos-cookbooks/composer'
 issues_url 'https://github.com/djoos-cookbooks/composer/issues'
 
-depends 'apt'
 depends 'php'
-depends 'windows'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,5 +12,3 @@ end
 
 source_url 'https://github.com/djoos-cookbooks/composer'
 issues_url 'https://github.com/djoos-cookbooks/composer/issues'
-
-depends 'php'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Recipe:: default
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 include_recipe 'composer::install'

--- a/recipes/global_configs.rb
+++ b/recipes/global_configs.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Recipe:: global_configs
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 configs = node['composer']['global_configs']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Recipe:: install
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 include_recipe node['composer']['php_recipe']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -34,7 +34,6 @@ else
   remote_file file do
     source node['composer']['url']
     mode node['composer']['mask']
-    action :create
-    not_if { ::File.exist?(file) }
+    action :create_if_missing
   end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,7 +5,11 @@
 # Copyright:: 2016-2022, David Joos
 #
 
-include_recipe node['composer']['php_recipe']
+log 'php check' do
+  level :fatal
+  message 'PHP is not installed. Please install PHP before including this recipe (e.g. with the `php` cookbook)'
+  not_if 'php --version'
+end
 
 if platform?('windows')
   windows_package 'Composer - PHP Dependency Manager' do

--- a/recipes/self_update.rb
+++ b/recipes/self_update.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Recipe:: self_update
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 include_recipe 'composer::install'

--- a/resources/install_global.rb
+++ b/resources/install_global.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Resource:: install_global
 #
-# Copyright:: 2012-2021, Escape Studios
+# Copyright:: 2012-2022, Escape Studios
 #
 
 unified_mode true

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -2,7 +2,7 @@
 # Cookbook:: composer
 # Resource:: project
 #
-# Copyright:: 2016-2021, David Joos
+# Copyright:: 2016-2022, David Joos
 #
 
 unified_mode true

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -4,6 +4,7 @@ describe 'composer::default' do
   platform 'ubuntu'
 
   before do
+    stub_command('php --version')
     stub_command("php -m | grep 'Phar'").and_return(true)
   end
 

--- a/test/integration/default/inspec/install_spec.rb
+++ b/test/integration/default/inspec/install_spec.rb
@@ -2,3 +2,7 @@ describe file('/usr/local/bin/composer') do
   it { should exist }
   its('mode') { should cmp '0755' }
 end
+
+describe command('composer --version') do
+  its('stdout') { should match /Composer version/ }
+end


### PR DESCRIPTION
This PR removes unneeded dependencies for resources in core Chef now, as these cookbooks are not maintained anymore and are not Chef 17/18 `unified_mode` compliant.

Supercedes #56.

## Changes

- Remove unneeded dependencies on `apt` / `windows` cookbooks for resources now in core Chef
- Adds testing on Alma / Rocky Linux 8

### Breaking

- Remove dependency on `php` cookbook
  - ⚠ This cookbook will no longer install PHP for you!
  - Use e.g. the `php` cookbook directly to install PHP before including these recipes
